### PR TITLE
Add basic FastAPI skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,26 @@
 
 Pequeña web app construida con FastAPI para la gestión de productos, clientes y ventas.
 
+
 ## Requisitos
 
 - Python 3.10+
-- Instalar dependencias con `pip install -r requirements.txt`
+- [Visual Studio Code](https://code.visualstudio.com/) en Windows
+
+Instala las dependencias dentro de un entorno virtual:
+
+```powershell
+python -m venv venv
+venv\Scripts\activate
+pip install -r requirements.txt
+```
 
 ## Uso
 
-```bash
-uvicorn app.main:app --reload
+Ejecuta la API en modo desarrollo desde la terminal integrada de VS Code:
+
+```powershell
+python -m uvicorn app.main:app --reload
 ```
 
 La API estará disponible en `http://localhost:8000/`.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# ShowroomOjitOs
+# Showroom Natura OjitOs
+
+Pequeña web app construida con FastAPI para la gestión de productos, clientes y ventas.
+
+## Requisitos
+
+- Python 3.10+
+- Instalar dependencias con `pip install -r requirements.txt`
+
+## Uso
+
+```bash
+uvicorn app.main:app --reload
+```
+
+La API estará disponible en `http://localhost:8000/`.

--- a/README.md
+++ b/README.md
@@ -25,3 +25,5 @@ python -m uvicorn app.main:app --reload
 ```
 
 La API estará disponible en `http://localhost:8000/`.
+
+Los archivos estáticos (CSS, imágenes, JS) se cargan desde el directorio `static/`. Asegúrate de mantenerlo presente para evitar errores al iniciar la aplicación.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Pequeña web app construida con FastAPI para la gestión de productos, clientes 
 
 - Python 3.10+
 - [Visual Studio Code](https://code.visualstudio.com/) en Windows
+- Jinja2 (se instala con `pip install -r requirements.txt`)
 
 Instala las dependencias dentro de un entorno virtual:
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+"""Backend package for Showroom Natura OjitOs."""

--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,12 @@
+from sqlmodel import SQLModel, create_engine, Session
+
+DATABASE_URL = "sqlite:///./showroom.db"
+engine = create_engine(DATABASE_URL, echo=False)
+
+
+def init_db():
+    SQLModel.metadata.create_all(engine)
+
+
+def get_session():
+    return Session(engine)

--- a/app/main.py
+++ b/app/main.py
@@ -4,7 +4,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
 from app.database import init_db
-from app.routers import products, clients, sales, users, categories
+from app.routers import products, clients, sales, users, categories, tags
 
 app = FastAPI(title="Showroom Natura OjitOs")
 
@@ -24,6 +24,7 @@ app.include_router(clients.router)
 app.include_router(sales.router)
 app.include_router(users.router)
 app.include_router(categories.router)
+app.include_router(tags.router)
 
 
 @app.on_event("startup")

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,36 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+
+from app.database import init_db
+from app.routers import products, clients, sales, users, categories
+
+app = FastAPI(title="Showroom Natura OjitOs")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+app.mount("/static", StaticFiles(directory="static"), name="static")
+templates = Jinja2Templates(directory="app/templates")
+
+app.include_router(products.router)
+app.include_router(clients.router)
+app.include_router(sales.router)
+app.include_router(users.router)
+app.include_router(categories.router)
+
+
+@app.on_event("startup")
+def on_startup():
+    init_db()
+
+
+@app.get("/")
+def read_root():
+    return {"message": "Showroom Natura OjitOs API"}

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,54 @@
+from typing import Optional, List
+from datetime import datetime
+from sqlmodel import SQLModel, Field, Relationship
+
+
+class User(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    username: str = Field(index=True)
+    password: str
+    role: str = "vendedor"  # admin, vendedor, cliente
+
+
+class Category(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    nombre: str
+    productos: List["Product"] = Relationship(back_populates="categoria")
+
+
+class Product(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    nombre: str
+    precio_revista: float
+    precio_showroom: float
+    precio_feria: float
+    stock_actual: int
+    stock_critico: int
+    categoria_id: Optional[int] = Field(default=None, foreign_key="category.id")
+
+    categoria: Optional[Category] = Relationship(back_populates="productos")
+
+
+class Client(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    nombre_completo: str
+    whatsapp: str
+    email: Optional[str]
+    nivel: str = "Plata"  # Plata, Diamante
+
+
+class SaleItem(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    sale_id: Optional[int] = Field(default=None, foreign_key="sale.id")
+    product_id: Optional[int] = Field(default=None, foreign_key="product.id")
+    cantidad: int
+    precio: float
+
+
+class Sale(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    cliente_id: Optional[int] = Field(default=None, foreign_key="client.id")
+    fecha: datetime = Field(default_factory=datetime.utcnow)
+    estado: str = "Armado"  # Armado, Entregado, Cobrado
+    total: float = 0
+

--- a/app/models.py
+++ b/app/models.py
@@ -16,15 +16,15 @@ class Category(SQLModel, table=True):
     productos: List["Product"] = Relationship(back_populates="categoria")
 
 
-class Tag(SQLModel, table=True):
-    id: Optional[int] = Field(default=None, primary_key=True)
-    nombre: str
-    productos: List["Product"] = Relationship(back_populates="tags", link_model="ProductTag")
-
-
 class ProductTag(SQLModel, table=True):
     product_id: Optional[int] = Field(default=None, foreign_key="product.id", primary_key=True)
     tag_id: Optional[int] = Field(default=None, foreign_key="tag.id", primary_key=True)
+
+
+class Tag(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    nombre: str
+    productos: List["Product"] = Relationship(back_populates="tags", link_model=ProductTag)
 
 
 class Product(SQLModel, table=True):

--- a/app/models.py
+++ b/app/models.py
@@ -16,6 +16,17 @@ class Category(SQLModel, table=True):
     productos: List["Product"] = Relationship(back_populates="categoria")
 
 
+class Tag(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    nombre: str
+    productos: List["Product"] = Relationship(back_populates="tags", link_model="ProductTag")
+
+
+class ProductTag(SQLModel, table=True):
+    product_id: Optional[int] = Field(default=None, foreign_key="product.id", primary_key=True)
+    tag_id: Optional[int] = Field(default=None, foreign_key="tag.id", primary_key=True)
+
+
 class Product(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     nombre: str
@@ -28,6 +39,7 @@ class Product(SQLModel, table=True):
 
     categoria: Optional[Category] = Relationship(back_populates="productos")
 
+    tags: List[Tag] = Relationship(back_populates="productos", link_model=ProductTag)
 
 class Client(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -1,0 +1,10 @@
+from . import products, clients, sales, users, categories, tags
+
+__all__ = [
+    "products",
+    "clients",
+    "sales",
+    "users",
+    "categories",
+    "tags",
+]

--- a/app/routers/categories.py
+++ b/app/routers/categories.py
@@ -1,0 +1,19 @@
+from fastapi import APIRouter, Depends
+from sqlmodel import select
+from app.models import Category
+from app.database import get_session
+
+router = APIRouter(prefix="/categories", tags=["categories"])
+
+
+@router.get("/", response_model=list[Category])
+def read_categories(session=Depends(get_session)):
+    return session.exec(select(Category)).all()
+
+
+@router.post("/", response_model=Category)
+def create_category(category: Category, session=Depends(get_session)):
+    session.add(category)
+    session.commit()
+    session.refresh(category)
+    return category

--- a/app/routers/clients.py
+++ b/app/routers/clients.py
@@ -1,0 +1,27 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlmodel import select
+from app.models import Client
+from app.database import get_session
+
+router = APIRouter(prefix="/clients", tags=["clients"])
+
+
+@router.get("/", response_model=list[Client])
+def read_clients(session=Depends(get_session)):
+    return session.exec(select(Client)).all()
+
+
+@router.post("/", response_model=Client)
+def create_client(client: Client, session=Depends(get_session)):
+    session.add(client)
+    session.commit()
+    session.refresh(client)
+    return client
+
+
+@router.get("/{client_id}", response_model=Client)
+def get_client(client_id: int, session=Depends(get_session)):
+    client = session.get(Client, client_id)
+    if not client:
+        raise HTTPException(status_code=404, detail="Client not found")
+    return client

--- a/app/routers/products.py
+++ b/app/routers/products.py
@@ -1,0 +1,27 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlmodel import select
+from app.models import Product
+from app.database import get_session
+
+router = APIRouter(prefix="/products", tags=["products"])
+
+
+@router.get("/", response_model=list[Product])
+def read_products(session=Depends(get_session)):
+    return session.exec(select(Product)).all()
+
+
+@router.post("/", response_model=Product)
+def create_product(product: Product, session=Depends(get_session)):
+    session.add(product)
+    session.commit()
+    session.refresh(product)
+    return product
+
+
+@router.get("/{product_id}", response_model=Product)
+def get_product(product_id: int, session=Depends(get_session)):
+    product = session.get(Product, product_id)
+    if not product:
+        raise HTTPException(status_code=404, detail="Product not found")
+    return product

--- a/app/routers/sales.py
+++ b/app/routers/sales.py
@@ -1,0 +1,27 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlmodel import select
+from app.models import Sale, SaleItem
+from app.database import get_session
+
+router = APIRouter(prefix="/sales", tags=["sales"])
+
+
+@router.get("/", response_model=list[Sale])
+def read_sales(session=Depends(get_session)):
+    return session.exec(select(Sale)).all()
+
+
+@router.post("/", response_model=Sale)
+def create_sale(sale: Sale, session=Depends(get_session)):
+    session.add(sale)
+    session.commit()
+    session.refresh(sale)
+    return sale
+
+
+@router.get("/{sale_id}", response_model=Sale)
+def get_sale(sale_id: int, session=Depends(get_session)):
+    sale = session.get(Sale, sale_id)
+    if not sale:
+        raise HTTPException(status_code=404, detail="Sale not found")
+    return sale

--- a/app/routers/tags.py
+++ b/app/routers/tags.py
@@ -1,0 +1,17 @@
+from fastapi import APIRouter, Depends
+from sqlmodel import select
+from app.models import Tag
+from app.database import get_session
+
+router = APIRouter(prefix="/tags", tags=["tags"])
+
+@router.get("/", response_model=list[Tag])
+def read_tags(session=Depends(get_session)):
+    return session.exec(select(Tag)).all()
+
+@router.post("/", response_model=Tag)
+def create_tag(tag: Tag, session=Depends(get_session)):
+    session.add(tag)
+    session.commit()
+    session.refresh(tag)
+    return tag

--- a/app/routers/users.py
+++ b/app/routers/users.py
@@ -1,0 +1,27 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlmodel import select
+from app.models import User
+from app.database import get_session
+
+router = APIRouter(prefix="/users", tags=["users"])
+
+
+@router.get("/", response_model=list[User])
+def read_users(session=Depends(get_session)):
+    return session.exec(select(User)).all()
+
+
+@router.post("/", response_model=User)
+def create_user(user: User, session=Depends(get_session)):
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    return user
+
+
+@router.post("/login")
+def login(user: User, session=Depends(get_session)):
+    db_user = session.exec(select(User).where(User.username == user.username)).first()
+    if not db_user or db_user.password != user.password:
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+    return {"message": "Logged in"}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>Showroom Natura OjitOs</title>
+    <link href="https://fonts.googleapis.com/css2?family=Comfortaa&family=Roboto&display=swap" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/@material/web@0.1.0-beta.7/dist/material.min.css" rel="stylesheet">
+</head>
+<body>
+    <h1>Showroom Natura OjitOs</h1>
+    <p>API en funcionamiento</p>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+sqlmodel

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi
 uvicorn
 sqlmodel
+jinja2

--- a/static/README.md
+++ b/static/README.md
@@ -1,0 +1,1 @@
+# Static files


### PR DESCRIPTION
## Summary
- initialize FastAPI backend
- add models and routers for products, clients, sales, categories and users
- minimal HTML template
- setup requirements

## Testing
- `python -m py_compile $(find app -name '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684f949dc76c8323a49a81bc85a88376